### PR TITLE
trace folder creation happens during container creation to avoid run …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,7 @@ RUN useradd -G proton_user_group default_proton_user
 
 RUN mkdir -p /home/PROTON
 RUN mkdir -p /home/PROTON/proton-db
+RUN mkdir -p /home/PROTON/trace
 WORKDIR /home/PROTON
 COPY . /home/PROTON
 


### PR DESCRIPTION
trace folder creation happens during container creation to avoid run time failure.